### PR TITLE
LT-233 counter pagination values

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -111,6 +111,19 @@ class CounterSchema(BaseSchema):
     def get_operation(self, path, method):
         operation = super().get_operation(path, method)
         if method == "GET" and operation.get("operationId", "").startswith("list"):
+            result_schema = operation["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"]["properties"]["results"]
+            feature_collection = {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string", "example": "FeatureCollection"},
+                    "features": {"type": "array", "items": result_schema["items"]},
+                },
+            }
+            operation["responses"]["200"]["content"]["application/json"]["schema"][
+                "properties"
+            ]["results"] = feature_collection
             # Fixes OpenAPI types (defaults to string)
             type_mappings = {
                 "latitude": {"type": "number", "format": "float"},

--- a/api/views.py
+++ b/api/views.py
@@ -156,10 +156,8 @@ class CounterViewSet(
             geometry = GEOSGeometry(str(geojson_data), srid=4326)
             counters = Counter.objects.filter(geom__within=geometry)
             serializer = self.get_serializer(counters, many=True)
-            paginated_response = self.get_paginated_response(serializer.data).data
-            results = {"type": "FeatureCollection", "features": serializer.data}
-            response_data = {**paginated_response, "results": results}
-            return Response(response_data, status=200)
+            data = {"type": "FeatureCollection", "features": serializer.data}
+            return Response(data, status=200)
         except (
             TypeError,
             ValueError,

--- a/api/views.py
+++ b/api/views.py
@@ -156,8 +156,10 @@ class CounterViewSet(
             geometry = GEOSGeometry(str(geojson_data), srid=4326)
             counters = Counter.objects.filter(geom__within=geometry)
             serializer = self.get_serializer(counters, many=True)
-            data = {"type": "FeatureCollection", "features": serializer.data}
-            return Response(data, status=200)
+            paginated_response = self.get_paginated_response(serializer.data).data
+            results = {"type": "FeatureCollection", "features": serializer.data}
+            response_data = {**paginated_response, "results": results}
+            return Response(response_data, status=200)
         except (
             TypeError,
             ValueError,
@@ -182,8 +184,10 @@ class CounterViewSet(
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(self.paginate_queryset(queryset), many=True)
-        data = {"type": "FeatureCollection", "features": serializer.data}
-        return Response(data, status=200)
+        paginated_response = self.get_paginated_response(serializer.data).data
+        results = {"type": "FeatureCollection", "features": serializer.data}
+        response_data = {**paginated_response, "results": results}
+        return Response(response_data, status=200)
 
 
 class ObservationViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/openapi-schema.json
+++ b/openapi-schema.json
@@ -101,9 +101,18 @@
                       "example": "http://api.example.org/accounts/?page=2"
                     },
                     "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Counter"
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "FeatureCollection"
+                        },
+                        "features": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Counter"
+                          }
+                        }
                       }
                     }
                   }
@@ -130,9 +139,18 @@
                       "example": "http://api.example.org/accounts/?page=2"
                     },
                     "results": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Counter"
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "example": "FeatureCollection"
+                        },
+                        "features": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Counter"
+                          }
+                        }
                       }
                     }
                   }
@@ -339,12 +357,12 @@
         "description": "Returns a paged and sorted list of observations produced by counters,\nmatching the given search criteria.",
         "parameters": [
           {
-            "name": "page",
+            "name": "cursor",
             "required": false,
             "in": "query",
-            "description": "A page number within the paginated result set.",
+            "description": "The pagination cursor value.",
             "schema": {
-              "type": "integer"
+              "type": "string"
             }
           },
           {
@@ -352,6 +370,15 @@
             "required": false,
             "in": "query",
             "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set. If this parameter is set, it supercedes the cursor parameter and results will be returned as numbered pages.",
             "schema": {
               "type": "integer"
             }
@@ -462,21 +489,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "count": {
-                      "type": "integer",
-                      "example": 123
-                    },
                     "next": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=4"
+                      "nullable": true
                     },
                     "previous": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=2"
+                      "nullable": true
                     },
                     "results": {
                       "type": "array",
@@ -491,21 +510,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "count": {
-                      "type": "integer",
-                      "example": 123
-                    },
                     "next": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=4"
+                      "nullable": true
                     },
                     "previous": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=2"
+                      "nullable": true
                     },
                     "results": {
                       "type": "array",
@@ -531,12 +542,12 @@
         "description": "Returns a paged and sorted list of the observational data,\naggregated over the given period and matching the search criteria.",
         "parameters": [
           {
-            "name": "page",
+            "name": "cursor",
             "required": false,
             "in": "query",
-            "description": "A page number within the paginated result set.",
+            "description": "The pagination cursor value.",
             "schema": {
-              "type": "integer"
+              "type": "string"
             }
           },
           {
@@ -544,6 +555,15 @@
             "required": false,
             "in": "query",
             "description": "Number of results to return per page.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set. If this parameter is set, it supercedes the cursor parameter and results will be returned as numbered pages.",
             "schema": {
               "type": "integer"
             }
@@ -658,21 +678,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "count": {
-                      "type": "integer",
-                      "example": 123
-                    },
                     "next": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=4"
+                      "nullable": true
                     },
                     "previous": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=2"
+                      "nullable": true
                     },
                     "results": {
                       "type": "array",
@@ -687,21 +699,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "count": {
-                      "type": "integer",
-                      "example": 123
-                    },
                     "next": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=4"
+                      "nullable": true
                     },
                     "previous": {
                       "type": "string",
-                      "nullable": true,
-                      "format": "uri",
-                      "example": "http://api.example.org/accounts/?page=2"
+                      "nullable": true
                     },
                     "results": {
                       "type": "array",


### PR DESCRIPTION
Counters endpoint now shows DRF pagination fields as intended (`count, previous, next, results`) and `type, feature` fields now wrapped within `results`. Schema formatting updated to reflect this change. 