### PR TITLE
LT-249 CSV retrieve support for counters and sources

### DIFF
--- a/api/renderers.py
+++ b/api/renderers.py
@@ -1,0 +1,10 @@
+from rest_framework_csv.renderers import PaginatedCSVRenderer
+
+
+class FeaturesPaginatedCSVRenderer(PaginatedCSVRenderer):
+    def render(self, data, media_type=None, renderer_context=None):
+        try:
+            data = data["results"]["features"]
+        except (KeyError, TypeError):
+            pass
+        return super().render(data, media_type, renderer_context)

--- a/api/views.py
+++ b/api/views.py
@@ -38,6 +38,8 @@ from .serializers import (
     ObservationSerializer,
     DatasourceSerializer,
 )
+from .renderers import FeaturesPaginatedCSVRenderer
+from rest_framework.settings import api_settings
 from rest_framework_csv import renderers
 
 # pylint: disable=no-member
@@ -138,7 +140,13 @@ class CounterViewSet(
     pagination_class = SmallResultsSetPagination
     serializer_class = CounterSerializer
     schema = CounterSchema(request_serializer=CounterFilterValidationSerializer)
-    queryset = Counter.objects.all()
+    queryset = Counter.objects.all
+    # Replace default DRF PaginatedCSVRenderer with custom renderer which maps the data from features object
+    renderer_classes = [
+        renderer
+        for renderer in api_settings.DEFAULT_RENDERER_CLASSES
+        if renderer != "rest_framework_csv.renderers.PaginatedCSVRenderer"
+    ] + [FeaturesPaginatedCSVRenderer]
 
     def get_queryset(self):
         try:

--- a/api/views.py
+++ b/api/views.py
@@ -140,7 +140,7 @@ class CounterViewSet(
     pagination_class = SmallResultsSetPagination
     serializer_class = CounterSerializer
     schema = CounterSchema(request_serializer=CounterFilterValidationSerializer)
-    queryset = Counter.objects.all
+    queryset = Counter.objects.all()
     # Replace default DRF PaginatedCSVRenderer with custom renderer which maps the data from features object
     renderer_classes = [
         renderer

--- a/api/views.py
+++ b/api/views.py
@@ -39,7 +39,7 @@ from .serializers import (
     DatasourceSerializer,
 )
 from .renderers import FeaturesPaginatedCSVRenderer
-from rest_framework_csv import renderers
+from rest_framework_csv.renderers import CSVRenderer
 from djangorestframework_camel_case.render import (
     CamelCaseJSONRenderer,
     CamelCaseBrowsableAPIRenderer,
@@ -122,7 +122,7 @@ class BaseCSVRetrieveViewSet(viewsets.GenericViewSet):
     def get_renderers(self):
         format = self.request.query_params.get("format")
         if format == "csv" and self.action == "retrieve":
-            return [renderers.CSVRenderer()]
+            return [CSVRenderer()]
         else:
             return super().get_renderers()
 

--- a/api/views.py
+++ b/api/views.py
@@ -39,8 +39,11 @@ from .serializers import (
     DatasourceSerializer,
 )
 from .renderers import FeaturesPaginatedCSVRenderer
-from rest_framework.settings import api_settings
 from rest_framework_csv import renderers
+from djangorestframework_camel_case.render import (
+    CamelCaseJSONRenderer,
+    CamelCaseBrowsableAPIRenderer,
+)
 
 # pylint: disable=no-member
 
@@ -141,12 +144,12 @@ class CounterViewSet(
     serializer_class = CounterSerializer
     schema = CounterSchema(request_serializer=CounterFilterValidationSerializer)
     queryset = Counter.objects.all()
-    # Replace default DRF PaginatedCSVRenderer with custom renderer which maps the data from features object
+    # Defining renderers explicitly to replace default PaginatedCSVRenderer with FeaturesPaginatedCSVRenderer which maps the data from features object
     renderer_classes = [
-        renderer
-        for renderer in api_settings.DEFAULT_RENDERER_CLASSES
-        if renderer != "rest_framework_csv.renderers.PaginatedCSVRenderer"
-    ] + [FeaturesPaginatedCSVRenderer]
+        CamelCaseJSONRenderer,
+        CamelCaseBrowsableAPIRenderer,
+        FeaturesPaginatedCSVRenderer,
+    ]
 
     def get_queryset(self):
         try:


### PR DESCRIPTION
Retrieval requests (individual elements) for counters and sources now produce CSV format output correctly, utilising a
custom ViewSet and renderer.