### PR TITLE
LT-194 new counter properties

### DIFF
--- a/api/filters.py
+++ b/api/filters.py
@@ -85,7 +85,7 @@ class CounterFilter(FilterSet):
     municipality_code = NumberInFilter(
         field_name="municipality_code",
         lookup_expr="in",
-        label="Municipality code, leading zero is optional.",
+        label="Finnish municipality code of counter location (e.g. 091 for Helsinki, 092 for Vantaa, and 049 for Espoo), leading zero is optional. See further [Kuntanumero](https://fi.wikipedia.org/wiki/Kuntanumero).",
     )
 
     def distance_filter(self, _queryset, _name, _value):

--- a/api/filters.py
+++ b/api/filters.py
@@ -143,12 +143,12 @@ class ObservationAggregateFilter(FilterSet):
         label="Counter id, aggregates observations of selected counter.",
     )
     start_date = DateFilter(
-        field_name="start_time",
+        field_name="datetime",
         lookup_expr="gte",
         label="Start date of measurement period.",
     )
     end_date = DateFilter(
-        field_name="start_time",
+        field_name="datetime",
         method=filter_end_date,
         label="End date of measurement period.",
     )

--- a/api/filters.py
+++ b/api/filters.py
@@ -82,6 +82,11 @@ class CounterFilter(FilterSet):
         label="Distance in kilometers, how far can a counter be from the defined point.",
     )
     source = CharFilter(field_name="source", lookup_expr="iexact", label="Data source.")
+    municipality_code = NumberInFilter(
+        field_name="municipality_code",
+        lookup_expr="in",
+        label="Municipality code, leading zero is optional.",
+    )
 
     def distance_filter(self, _queryset, _name, _value):
         query_params = self.request.query_params

--- a/api/models.py
+++ b/api/models.py
@@ -44,6 +44,11 @@ class Counter(ReadOnlyModel):
     crs_epsg = models.BigIntegerField()
     source = models.CharField(max_length=32)
     geom = gis_models.PointField()
+    source_id = models.IntegerField()
+    municipality_code = models.IntegerField()
+    data_received = models.BooleanField()
+    first_stored_observation = models.DateTimeField()
+    last_stored_observation = models.DateTimeField()
 
 
 class Observation(ReadOnlyModel):

--- a/api/paginators.py
+++ b/api/paginators.py
@@ -188,7 +188,6 @@ class CompoundCursorPagination(CursorPagination):
 
         if isinstance(ordering, str):
             ordering = (ordering,)
-
         return tuple(ordering)
 
     def _get_position_from_instance(self, instance, ordering):
@@ -202,7 +201,6 @@ class CompoundCursorPagination(CursorPagination):
                 attr = getattr(instance, field_name)
 
             fields.append(str(attr))
-
         return json.dumps(fields)
 
 
@@ -271,3 +269,10 @@ class ObservationAggregateCursorPagination(CompoundCursorPagination):
 
         parameters.append(page_parameter)
         return parameters
+
+    def get_ordering(self, request, queryset, view):
+        ordering = super().get_ordering(request, queryset, view)
+        if "order" in request.query_params:
+            fixed_orderings = ["counter_id", "direction"]
+            ordering = [request.query_params.get("order")] + fixed_orderings
+        return ordering

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -39,6 +39,7 @@ class CounterSerializer(serializers.HyperlinkedModelSerializer, ReadOnlySerializ
         return {"type": "Point", "coordinates": [obj.geom.x, obj.geom.y]}
 
     def get_properties(self, obj):
+        datetime_serializer = serializers.DateTimeField()
         return {
             "id": obj.id,
             "name": obj.name,
@@ -49,8 +50,12 @@ class CounterSerializer(serializers.HyperlinkedModelSerializer, ReadOnlySerializ
             # Municipality codes stored in database as integers but correct format includes a leading zero
             "municipality_code": f"0{obj.municipality_code}",
             "data_received": obj.data_received,
-            "first_stored_observation": obj.first_stored_observation,
-            "last_stored_observation": obj.last_stored_observation,
+            "first_stored_observation": datetime_serializer.to_representation(
+                obj.first_stored_observation
+            ),
+            "last_stored_obs": datetime_serializer.to_representation(
+                obj.last_stored_observation
+            ),
         }
 
     def to_representation(self, instance):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -53,7 +53,7 @@ class CounterSerializer(serializers.HyperlinkedModelSerializer, ReadOnlySerializ
             "first_stored_observation": datetime_serializer.to_representation(
                 obj.first_stored_observation
             ),
-            "last_stored_obs": datetime_serializer.to_representation(
+            "last_stored_observation": datetime_serializer.to_representation(
                 obj.last_stored_observation
             ),
         }

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -43,8 +43,14 @@ class CounterSerializer(serializers.HyperlinkedModelSerializer, ReadOnlySerializ
             "id": obj.id,
             "name": obj.name,
             "source": obj.source,
+            "source_id": obj.source_id,
             "classifying": obj.classifying,
             "crs_epsg": obj.crs_epsg,
+            # Municipality codes stored in database as integers but correct format includes a leading zero
+            "municipality_code": f"0{obj.municipality_code}",
+            "data_received": obj.data_received,
+            "first_stored_observation": obj.first_stored_observation,
+            "last_stored_observation": obj.last_stored_observation,
         }
 
     def to_representation(self, instance):

--- a/api/views.py
+++ b/api/views.py
@@ -219,13 +219,6 @@ class ObservationAggregateViewSet(mixins.ListModelMixin, viewsets.GenericViewSet
         if "page" in self.request.query_params:
             self.pagination_class = LargeResultsSetPagination
 
-        elif "order" in self.request.query_params:
-            self.pagination_class.ordering = [
-                self.request.query_params.get("order"),
-                "counter_id",
-                "direction",
-            ]
-
         queryset = (
             self.queryset.values("typeofmeasurement", "source")
             .annotate(

--- a/api/views.py
+++ b/api/views.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+import pytz
 from django.contrib.gis.db.models.functions import Distance as DistanceFunction
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import GEOSGeometry, Point
@@ -227,7 +228,9 @@ class ObservationAggregateViewSet(mixins.ListModelMixin, viewsets.GenericViewSet
 
         queryset = (
             self.queryset.values("typeofmeasurement", "source")
-            .annotate(start_time=Trunc("datetime", kind=period))
+            .annotate(
+                start_time=Trunc("datetime", kind=period, tzinfo=pytz.timezone("UTC"))
+            )
             .values(
                 "start_time",
                 "counter_id",


### PR DESCRIPTION
Adding five new properties added to the return data of the 3 counter endpoints at the GeoJSON: Feature.properties level:

- sourceId – numeric like id
- dataReceived – boolean like classifying
- lastStoredObservation and lastStoredObservation – time stamp like datetime in the observations endpoints
- municipalityCode – numeric; in practice the values will be “091”, “092”, “049” corresponding to Helsinki, Vantaa, and Espoo – cf. [Finnish municipality number](https://www.wikidata.org/wiki/Property:P1203) 

Includes support for filtering counters by municipality code