### PR TITLE
LT 241 test expansion

### DIFF
--- a/api/tests/test_counters.py
+++ b/api/tests/test_counters.py
@@ -1,0 +1,220 @@
+import pytest
+from django.urls import reverse
+from django.contrib.gis.geos import GEOSGeometry, Point
+from django.contrib.gis.db.models.functions import Distance
+from geopy.distance import geodesic
+from api.models import Datasource, Counter
+from api.views import CounterViewSet
+
+
+@pytest.fixture
+def middle_counter():
+    counters = Counter.objects.all().order_by("longitude")
+    return counters[len(counters) // 2]
+
+
+@pytest.fixture
+def geojson_area():
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [[24.5, 60.2], [24.5, 60.9], [24.8, 60.9], [24.98, 59.9], [24.5, 60.2]]
+        ],
+    }
+
+
+# Distance filter returns valid counters within the given distance
+@pytest.mark.django_db
+def test_coordinates_distance(api_client, middle_counter):
+    url = reverse("counter-list")
+    query_point_params = {
+        "latitude": middle_counter.latitude,
+        "longitude": middle_counter.longitude,
+        "distance": 2,
+        "page_size": CounterViewSet.pagination_class().max_page_size,
+    }
+    response = api_client.get(url, query_point_params)
+
+    while response:
+        counters = response.data["results"]["features"]
+        for counter in counters:
+            counter_point = Point(
+                x=counter["geometry"]["coordinates"][0],
+                y=counter["geometry"]["coordinates"][1],
+                srid=4326,
+            )
+            assert (
+                geodesic(
+                    (middle_counter.latitude, middle_counter.longitude),
+                    (counter_point.y, counter_point.x),
+                )
+                <= 2.0
+            )
+        if response.data["next"]:
+            response = api_client.get(response.data["next"])
+        else:
+            break
+
+
+# Zero distance should only return the exact counter whose coordinates given as parameters
+@pytest.mark.django_db
+def test_coordinates_zero_distance(api_client):
+    url = reverse("counter-list")
+    response = api_client.get(url)
+    counter = response.data["results"]["features"]
+    counter_coordinates = counter[0]["geometry"]["coordinates"]
+    query_point_params = {
+        "latitude": counter_coordinates[1],
+        "longitude": counter_coordinates[0],
+        "distance": 0,
+    }
+    counter_response = api_client.get(url, query_point_params)
+    assert len(counter_response.data["results"]["features"]) == 1
+
+    response_point = response.data["results"]["features"][0]
+    assert counter_coordinates[0] == response_point["geometry"]["coordinates"][0]
+    assert counter_coordinates[1] == response_point["geometry"]["coordinates"][1]
+
+
+@pytest.mark.django_db
+def test_single_source_filter(api_client):
+    url = reverse("counter-list")
+    datasource_name = Datasource.objects.values_list("name", flat=True)[0]
+    response = api_client.get(
+        url,
+        {
+            "source": datasource_name,
+            "page_size": CounterViewSet.pagination_class().max_page_size,
+        },
+    )
+    while response:
+        counters = response.data["results"]["features"]
+        for counter in counters:
+            assert counter["properties"]["source"] == datasource_name
+
+        if response.data["next"]:
+            response = api_client.get(response.data["next"])
+        else:
+            break
+
+
+@pytest.mark.django_db
+def test_multiple_source_filter(api_client):
+    url = reverse("counter-list")
+    datasource_names = Datasource.objects.values_list("name", flat=True)
+    datasource_names_subset = datasource_names[: (len(datasource_names) // 2)]
+    response = api_client.get(
+        url,
+        {
+            "source": ",".join(datasource_names_subset),
+            "page_size": CounterViewSet.pagination_class().max_page_size,
+        },
+    )
+    while response:
+        counters = response.data["results"]["features"]
+        for counter in counters:
+            assert counter["properties"]["source"] in datasource_names_subset
+
+        if response.data["next"]:
+            response = api_client.get(response.data["next"])
+        else:
+            break
+
+
+@pytest.mark.django_db
+def test_single_source_multiple_counters_distance_filter(api_client, middle_counter):
+    url = reverse("counter-list")
+    response = api_client.get(
+        url,
+        {
+            "source": middle_counter.source,
+            "latitude": middle_counter.latitude,
+            "longitude": middle_counter.longitude,
+            "distance": 2,
+            "page_size": CounterViewSet.pagination_class().max_page_size,
+        },
+    )
+    while response:
+        counters = response.data["results"]["features"]
+        for counter in counters:
+            counter_point = Point(
+                x=counter["geometry"]["coordinates"][0],
+                y=counter["geometry"]["coordinates"][1],
+                srid=4326,
+            )
+            assert (
+                geodesic(
+                    (middle_counter.latitude, middle_counter.longitude),
+                    (counter_point.y, counter_point.x),
+                )
+                <= 2.0
+            )
+            assert counter["properties"]["source"] == middle_counter.source
+
+        if response.data["next"]:
+            response = api_client.get(response.data["next"])
+        else:
+            break
+
+
+@pytest.mark.django_db
+def test_multple_source_multiple_counters_distance_filter(api_client, middle_counter):
+    url = reverse("counter-list")
+    datasource_names = Datasource.objects.values_list("name", flat=True)
+    datasource_names_subset = datasource_names[: (len(datasource_names) // 2)]
+    response = api_client.get(
+        url,
+        {
+            "source": ",".join(datasource_names_subset),
+            "latitude": middle_counter.latitude,
+            "longitude": middle_counter.longitude,
+            "distance": 2,
+            "page_size": CounterViewSet.pagination_class().max_page_size,
+        },
+    )
+    while response:
+        response_counters = response.data["results"]["features"]
+        for counter in response_counters:
+            counter_point = Point(
+                x=counter["geometry"]["coordinates"][0],
+                y=counter["geometry"]["coordinates"][1],
+                srid=4326,
+            )
+            assert (
+                geodesic(
+                    (middle_counter.latitude, middle_counter.longitude),
+                    (counter_point.y, counter_point.x),
+                )
+                <= 2.0
+            )
+            assert counter["properties"]["source"] in datasource_names_subset
+
+        if response.data["next"]:
+            response = api_client.get(response.data["next"])
+        else:
+            break
+
+
+# Returned counters should be within the provided GeoJSON area
+@pytest.mark.django_db
+def test_geojson_area_filter(api_client, geojson_area):
+    url = reverse("counter-list")
+    response = api_client.post(url, data=geojson_area, format="json")
+    geometry = GEOSGeometry(str(geojson_area), srid=4326)
+    response_counters = response.data["features"]
+    for counter in response_counters:
+        counter_point = Point(
+            x=counter["geometry"]["coordinates"][0],
+            y=counter["geometry"]["coordinates"][1],
+            srid=4326,
+        )
+        assert geometry.contains(counter_point)
+
+    outside_counters = Counter.objects.exclude(geom__within=geometry)
+    for counter in outside_counters:
+        counter_point = Point(
+            y=counter.latitude,
+            x=counter.longitude,
+            srid=4326,
+        )
+        assert not geometry.contains(counter_point)

--- a/api/tests/test_observations.py
+++ b/api/tests/test_observations.py
@@ -1,0 +1,134 @@
+import math
+from datetime import datetime
+
+import pytest
+import pytz
+from django.db.models import Count
+from django.urls import reverse
+from django.utils.timezone import make_aware
+
+from api.models import Counter, Datasource, Observation
+
+
+@pytest.fixture()
+def observation_parameters():
+    counter = (
+        Counter.objects.annotate(observation_count=Count("observation"))
+        .filter(observation_count__gte=10000)
+        .first()
+    )
+    datetimes = list(
+        Observation.objects.order_by("datetime")
+        .filter(counter_id=counter.id)
+        .values_list("datetime", flat=True)[:10000]
+    )
+    return {
+        "start_date": datetimes[0].date(),
+        "end_date": datetimes[-1].date(),
+        "counter": counter.id,
+        "page_size": 1000,
+    }
+
+
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_date_range_filter(api_client, observation_parameters):
+    url = reverse("observation-list")
+    response = api_client.get(
+        url,
+        {**observation_parameters},
+    )
+    first_datetime = datetime.fromisoformat(response.data["results"][0]["datetime"])
+    start_datetime = make_aware(
+        datetime.combine(observation_parameters["start_date"], datetime.min.time()),
+        pytz.timezone("Europe/Helsinki"),
+    )
+    assert first_datetime >= start_datetime
+
+    while response.data["next"]:
+        next_response = api_client.get(response.data["next"])
+        response = next_response
+    last_datetime = datetime.fromisoformat(response.data["results"][-1]["datetime"])
+    end_datetime = make_aware(
+        datetime.combine(observation_parameters["end_date"], datetime.max.time())
+    )
+    assert last_datetime <= end_datetime
+
+
+@pytest.mark.django_db
+def test_multiple_counter_filter(api_client):
+    url = reverse("observation-list")
+    counter_ids = (
+        Counter.objects.filter(observation__isnull=False)
+        .distinct()
+        .values_list("id", flat=True)[:5]
+    )
+    response = api_client.get(url, {"counter": counter_ids})
+
+    for observation in response.data["results"]:
+        assert (observation["counter_id"]) in counter_ids
+
+
+@pytest.mark.django_db
+def test_source_filter(api_client):
+    url = reverse("observation-list")
+    datasource_name = Datasource.objects.values_list("name", flat=True)[0]
+    response = api_client.get(
+        url, {"source": datasource_name, "page": 1, "page_size": 1000}
+    )
+    total_count = response.data["count"]
+    total_pages = math.ceil(total_count / 1000)
+
+    # Only check 10 pages for speed, there may be a large count of pages
+    page_interval = total_pages // (10)
+    i = 1
+    while i <= total_pages:
+        response = api_client.get(
+            url,
+            {"source": datasource_name, "page": i, "page_size": 1000},
+        )
+        response_observations = response.data["results"]
+        for observation in response_observations:
+            assert observation["source"] == datasource_name
+        i += page_interval
+
+
+@pytest.mark.django_db
+def test_source_and_counter_filter(api_client):
+    url = reverse("observation-list")
+    datasource_names = Datasource.objects.values_list("name", flat=True)
+    datasource_name = datasource_names[0]
+    valid_counter_ids = (
+        Counter.objects.filter(source=datasource_name, observation__isnull=False)
+        .values_list("id", flat=True)
+        .distinct()[:5]
+    )
+    invalid_counter_ids = (
+        Counter.objects.exclude(source=datasource_name)
+        .distinct()
+        .values_list("id", flat=True)[:5]
+    )
+
+    valid_counters_response = api_client.get(
+        url, {"source": datasource_name, "counter": valid_counter_ids, "page": 1}
+    )
+    total_count = valid_counters_response.data["count"]
+    total_pages = math.ceil(total_count / 1000)
+    page_interval = total_pages // (10)
+
+    i = page_interval
+    while i <= total_pages:
+        for observation in valid_counters_response.data["results"]:
+            assert observation["source"] == datasource_name
+            assert observation["counter_id"] in valid_counter_ids
+        valid_counters_response = api_client.get(
+            url, {"source": datasource_name, "counter": valid_counter_ids, "page": i}
+        )
+        i += page_interval
+
+    invalid_counter_ids_response = api_client.get(
+        url, {"source": datasource_name, "counter": invalid_counter_ids}
+    )
+    assert len(invalid_counter_ids_response.data["results"]) == 0

--- a/api/tests/test_observations_aggregate.py
+++ b/api/tests/test_observations_aggregate.py
@@ -1,0 +1,200 @@
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from django.db.models import Count
+from django.urls import reverse
+from django.utils.timezone import make_aware
+
+from api.models import Counter, Observation
+
+
+@pytest.fixture()
+def aggregate_observation_parameters():
+    counter = (
+        Counter.objects.annotate(observation_count=Count("observation"))
+        .filter(observation_count__gte=10000)
+        .first()
+    )
+    datetimes = list(
+        Observation.objects.order_by("datetime")
+        .filter(counter_id=counter.id)
+        .values_list("datetime", flat=True)[:10000]
+    )
+    return {
+        "start_date": datetimes[0].date(),
+        "end_date": datetimes[-1].date(),
+        "counter": counter.id,
+        "measurement_type": "count",
+    }
+
+
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_observations_aggregate_date_filter(
+    api_client, aggregate_observation_parameters
+):
+    url = reverse("observation-aggregate-list")
+    response = api_client.get(
+        url,
+        {
+            **aggregate_observation_parameters,
+            "period": "hour",
+        },
+    )
+    first_datetime = datetime.fromisoformat(response.data["results"][0]["start_time"])
+    start_datetime = make_aware(
+        datetime.combine(
+            aggregate_observation_parameters["start_date"], datetime.min.time()
+        ),
+        timezone=pytz.timezone("Europe/Helsinki"),
+    )
+    assert first_datetime >= start_datetime
+
+    while response.data["next"]:
+        next_response = api_client.get(response.data["next"])
+        response = next_response
+    last_datetime = datetime.fromisoformat(response.data["results"][-1]["start_time"])
+    end_datetime = make_aware(
+        datetime.combine(
+            aggregate_observation_parameters["end_date"], datetime.max.time()
+        ),
+        timezone=pytz.timezone("Europe/Helsinki"),
+    )
+    assert last_datetime <= end_datetime
+
+
+# Page contents do not overlap at datetime boundaries.
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_datetime_no_overlap(api_client, aggregate_observation_parameters):
+    url = reverse("observation-aggregate-list")
+    response = api_client.get(
+        url,
+        {
+            **aggregate_observation_parameters,
+            "period": "hour",
+            "order": "start_time",
+            "page": 1,
+            "page_size": 3,
+        },
+    )
+
+    while response.data["next"]:
+        for current_observation, next_observation in zip(
+            response.data["results"], response.data["results"][1:]
+        ):
+            current_observation_datetime = datetime.fromisoformat(
+                current_observation["start_time"]
+            )
+            next_observation_datetime = datetime.fromisoformat(
+                next_observation["start_time"]
+            )
+            assert (
+                next_observation_datetime
+                == current_observation_datetime + timedelta(hours=1)
+            )
+        last_current_page_datetime = datetime.fromisoformat(
+            response.data["results"][-1]["start_time"]
+        )
+        response = api_client.get(response.data["next"])
+        first_next_page_datetime = datetime.fromisoformat(
+            response.data["results"][0]["start_time"]
+        )
+        assert first_next_page_datetime == last_current_page_datetime + timedelta(
+            hours=1
+        )
+
+
+# Ordering works and defaults to -datetime,(counter_id,direction)
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_default_ordering(api_client):
+    url = reverse("observation-aggregate-list")
+    response = api_client.get(
+        url,
+        {
+            "start_date": "2023-02-01",
+            "end_date": "2023-02-04",
+            "period": "hour",
+            "measurement_type": "count",
+            "counter": 1,
+            "page": 1,
+            "page_size": 3,
+        },
+    )
+
+    while response.data["next"]:
+        for current_observation, next_observation in zip(
+            response.data["results"], response.data["results"][1:]
+        ):
+            assert current_observation["start_time"] > next_observation["start_time"]
+        response = api_client.get(response.data["next"])
+
+
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_reverse_ordering(api_client):
+    url = reverse("observation-aggregate-list")
+    response = api_client.get(
+        url,
+        {
+            "start_date": "2023-02-01",
+            "end_date": "2023-02-04",
+            "period": "hour",
+            "measurement_type": "count",
+            "counter": 1,
+            "page": 1,
+            "page_size": 3,
+            "order": "start_time",
+        },
+    )
+
+    while response.data["next"]:
+        for current_observation, next_observation in zip(
+            response.data["results"], response.data["results"][1:]
+        ):
+            assert current_observation["start_time"] < next_observation["start_time"]
+        response = api_client.get(response.data["next"])
+
+
+# Multiple counter id
+
+
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_multiple_counters(api_client):
+    url = reverse("observation-aggregate-list")
+    valid_counter_ids = (
+        Counter.objects.filter(observation__isnull=False)
+        .values_list("id", flat=True)
+        .distinct()[:5]
+    )
+    response = api_client.get(
+        url,
+        {
+            "start_date": "2023-02-01",
+            "end_date": "2023-02-04",
+            "period": "hour",
+            "measurement_type": "count",
+            "counter": valid_counter_ids,
+            "page": 1,
+            "page_size": 3,
+            "order": "start_time",
+        },
+    )
+
+    while response.data["next"]:
+        for observation in response.data["results"]:
+            assert observation["counter_id"] in valid_counter_ids
+        response = api_client.get(response.data["next"])

--- a/api/tests/test_pagination.py
+++ b/api/tests/test_pagination.py
@@ -1,0 +1,264 @@
+import math
+import random
+
+import pytest
+from django.db.models import Count
+from django.urls import reverse
+
+from api.models import Counter, Observation
+from api.views import CounterViewSet
+
+
+@pytest.fixture()
+def observation_parameters():
+    counter = (
+        Counter.objects.annotate(observation_count=Count("observation"))
+        .filter(observation_count__gte=10000)
+        .first()
+    )
+    datetimes = list(
+        Observation.objects.order_by("-datetime")
+        .filter(counter_id=counter.id)
+        .values_list("datetime", flat=True)[:10000]
+    )
+    return {
+        "start_date": datetimes[-1].date(),
+        "end_date": datetimes[0].date(),
+        "counter": counter.id,
+        "page_size": 1000,
+    }
+
+
+# Observations should default to cursor pagination
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_cursor_default(api_client, observation_parameters):
+    url = reverse("observation-list")
+    response = api_client.get(url)
+    assert "cursor" in response.data["next"]
+
+    response = api_client.get(url, {**observation_parameters})
+    assert "cursor" in response.data["next"]
+
+
+# Observations when provided a page should use page number pagination
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_page_number_parameter(api_client, observation_parameters):
+    url = reverse("observation-list")
+    response = api_client.get(url, {"page": 1})
+    assert "cursor" not in response.data["next"]
+
+    response = api_client.get(
+        url,
+        {
+            **observation_parameters,
+            "page": 2,
+        },
+    )
+    assert "cursor" not in response.data["next"] and "page=3" in response.data["next"]
+
+
+# Default observations ordering is -datetime for both cursor and page number pagination
+@pytest.mark.django_db
+def test_observations_default_ordering(api_client):
+    url = reverse("observation-list")
+    page_num_response = api_client.get(url)
+
+    observations = page_num_response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] >= next_observation["datetime"]
+
+    response = api_client.get(url, {"page": "1"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] >= next_observation["datetime"]
+
+
+# Reverse observations ordering works for both cursor & page number pagination
+@pytest.mark.django_db
+def test_observations_reverse_ordering(api_client):
+    url = reverse("observation-list")
+    response = api_client.get(url, {"order": "datetime"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] <= next_observation["datetime"]
+
+    response = api_client.get(url, {"order": "datetime", "page": "1"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] <= next_observation["datetime"]
+
+
+# If only counter order parameter provided, counter criteria takes precedence
+@pytest.mark.django_db
+def test_observations_counter_ordering(api_client):
+    url = reverse("observation-list")
+    response = api_client.get(url, {"order": "counter"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] <= next_observation["counter_id"]
+
+    response = api_client.get(url, {"order": "counter", "page": "1"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] <= next_observation["counter_id"]
+
+
+# Counter reverse ordering
+@pytest.mark.django_db
+def test_observations_counter_reverse_ordering(api_client):
+    url = reverse("observation-list")
+    response = api_client.get(url, {"order": "-counter"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] >= next_observation["counter_id"]
+
+    response = api_client.get(url, {"order": "-counter", "page": "1"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] >= next_observation["counter_id"]
+
+
+# Cursor pagination: if datetime and counter both provided, first takes precedence
+@pytest.mark.django_db
+def test_observations_cursor_both_order_parameters(api_client):
+    # Cursor pagination
+    url = reverse("observation-list")
+    response = api_client.get(url, {"order": "datetime,-counter"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] <= next_observation["datetime"]
+        if current_observation["datetime"] == next_observation["datetime"]:
+            assert current_observation["counter"] <= current_observation["counter"]
+
+    response = api_client.get(url, {"order": "counter,-datetime"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] >= next_observation["counter_id"]
+        if current_observation["counter_id"] == next_observation["counter_id"]:
+            assert current_observation["datetime"] >= current_observation["datetime"]
+
+
+# PageNumber pagination: response includes an accurate total count
+@pytest.mark.django_db
+def test_page_number_pagination_total_count(api_client):
+    url = reverse("observation-list")
+    response = api_client.get(url, {"page": 1, "page_size": 1000})
+    total_count = response.data["count"]
+    final_page_response = api_client.get(url, {"page": math.ceil(total_count / 1000)})
+    assert (final_page_response.data["next"]) == None
+
+
+# PageNumber pagination: For datetime and counter both provided, first takes precedence
+@pytest.mark.django_db
+def test_observations_both_order_parameters(api_client):
+    # Cursor pagination
+    url = reverse("observation-list")
+    response = api_client.get(url, {"order": "datetime,-counter", "page": "3"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["datetime"] <= next_observation["datetime"]
+        if current_observation["datetime"] == next_observation["datetime"]:
+            assert current_observation["counter"] <= current_observation["counter"]
+
+    response = api_client.get(url, {"order": "counter,-datetime", "page": "3"})
+    observations = response.data["results"]
+    for current_observation, next_observation in zip(observations, observations[1:]):
+        assert current_observation["counter_id"] >= next_observation["counter_id"]
+        if current_observation["counter_id"] == next_observation["counter_id"]:
+            assert current_observation["datetime"] >= current_observation["datetime"]
+
+
+@pytest.mark.django_db
+def test_cursor_validity(api_client):
+    url = reverse("observation-list")
+    response = api_client.get(url)
+
+    second_page_url = response.data["next"]
+    second_page_response = api_client.get(second_page_url)
+    assert (
+        response.data["results"][-1]["datetime"]
+        >= second_page_response.data["results"][0]["datetime"]
+    )
+
+    third_page_url = second_page_response.data["next"]
+    third_page_response = api_client.get(third_page_url)
+    assert (
+        second_page_response.data["results"][-1]["datetime"]
+        >= third_page_response.data["results"][0]["datetime"]
+    )
+
+    previous_page_url = third_page_response.data["previous"]
+    previous_page_response = api_client.get(previous_page_url)
+    assert previous_page_response.data == second_page_response.data
+
+
+@pytest.mark.filterwarnings(
+    "ignore:DateTimeField Observation.datetime received a naive datetime"
+)
+@pytest.mark.django_db
+def test_cursor_validity_end(api_client, observation_parameters):
+    url = reverse("observation-list")
+    response = api_client.get(url, {**observation_parameters})
+
+    while response.data["next"]:
+        next_response = api_client.get(response.data["next"])
+        assert (
+            response.data["results"][-1]["datetime"]
+            >= next_response.data["results"][0]["datetime"]
+        )
+        response = next_response
+
+    assert response.data["next"] == None and response.data["previous"]
+
+
+# PageNumber pagination: response includes an accurate total count
+@pytest.mark.django_db
+def test_page_number_pagination_total_count(api_client):
+    url = reverse("counter-list")
+    response = api_client.get(url, {"page": 1})
+    total_count = response.data["count"]
+    page_size = len(response.data["results"]["features"])
+    num_pages = math.ceil(total_count / page_size)
+    final_page_response = api_client.get(url, {"page": num_pages})
+    assert (final_page_response.data["next"]) == None
+
+
+# Query paramater page_size=0 will use the default page size
+@pytest.mark.django_db
+def test_page_size_zero(api_client):
+    url = reverse("counter-list")
+    response = api_client.get(url, {"page_number": 0})
+    default_page_size = CounterViewSet.pagination_class().page_size
+    assert len(response.data["results"]["features"]) == default_page_size
+
+
+# Page size less than max can be set and returns a valid next link
+@pytest.mark.django_db
+def test_provided_page_size(api_client):
+    url = reverse("counter-list")
+    max_page_size = CounterViewSet.pagination_class().max_page_size
+    random_page_size = random.randint(1, max_page_size - 1)
+    response = api_client.get(url, {"page_size": random_page_size})
+    assert len(response.data["results"]["features"]) == random_page_size
+    second_page_url = response.data["next"]
+    second_page_response = api_client.get(second_page_url)
+    previous_page_response = api_client.get(second_page_response.data["previous"])
+    assert previous_page_response.data == response.data
+
+
+# Last page has no next link
+@pytest.mark.django_db
+def test_last_page_no_next_link(api_client):
+    url = reverse("counter-list")
+    first_page_response = api_client.get(url, {"page": 1})
+    total_count = first_page_response.data["count"]
+    page_size = len(first_page_response.data["results"]["features"])
+    num_pages = math.ceil(total_count / page_size)
+    final_page_response = api_client.get(url, {"page": num_pages})
+    assert (final_page_response.data["next"]) == None

--- a/api/tests/test_sources.py
+++ b/api/tests/test_sources.py
@@ -1,0 +1,32 @@
+import pytest
+from django.urls import reverse
+
+from api.models import Datasource
+
+
+@pytest.mark.django_db
+def test_default_ordering(api_client):
+    url = reverse("sources-list")
+    response = api_client.get(url)
+    sources = response.data
+    for current_source, next_source in zip(sources, sources[1:]):
+        assert current_source["name"] < next_source["name"]
+
+
+@pytest.mark.django_db
+def test_default_english_description(api_client):
+    url = reverse("sources-list")
+    response = api_client.get(url)
+    sources = response.data
+    english_descriptions = Datasource.objects.values_list("description_en", flat=True)
+
+    for source in sources:
+        assert source["description"] in english_descriptions
+
+
+@pytest.mark.django_db
+def test_default_invalid_language_parameter(api_client):
+    url = reverse("sources-list")
+    response = api_client.get(url, {"language": "de"})
+
+    assert response.status_code == 400

--- a/api/urls.py
+++ b/api/urls.py
@@ -11,7 +11,7 @@ router.register(
     views.ObservationAggregateViewSet,
     basename="observation-aggregate",
 )
-router.register(r"metadata/sources", views.DatasourcesViewSet, basename="sources")
+router.register(r"metadata/sources", views.DatasourceViewSet, basename="sources")
 
 
 urlpatterns = [

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
 
-import pytz
 from django.contrib.gis.db.models.functions import Distance as DistanceFunction
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import GEOSGeometry, Point
@@ -215,12 +214,10 @@ class ObservationAggregateViewSet(mixins.ListModelMixin, viewsets.GenericViewSet
             aggregation_calc: Avg | Sum = Avg("value")
         else:  # measurement_type == "count"
             aggregation_calc = Sum("value")
-            
+
         queryset = (
             self.queryset.values("typeofmeasurement", "source")
-            .annotate(
-                start_time=Trunc("datetime", kind=period, tzinfo=pytz.timezone("UTC"))
-            )
+            .annotate(start_time=Trunc("datetime", kind=period))
             .values(
                 "start_time",
                 "counter_id",

--- a/api/views.py
+++ b/api/views.py
@@ -239,7 +239,7 @@ class ObservationAggregateViewSet(mixins.ListModelMixin, viewsets.GenericViewSet
         return queryset
 
 
-class DatasourcesViewSet(
+class DatasourceViewSet(
     mixins.ListModelMixin, mixins.RetrieveModelMixin, BaseCSVRetrieveViewSet
 ):
     """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-django==4.5.2
 pytest-cov==4.1.0
 isort==5.12.0
 flake8==6.1.0
+geopy==2.4.1


### PR DESCRIPTION
- More extensive unit tests
- Return 400 error if user provides invalid language query parameter (instead of 500)
- Use default timezone when performing Trunc operation for aggregate observations